### PR TITLE
Add option to edit raw editor value and set search input type

### DIFF
--- a/frontend/components/Editor/Editor.js
+++ b/frontend/components/Editor/Editor.js
@@ -8,7 +8,7 @@ import { StyledEditor } from "./EditorStyled";
 import EditorTheme from "../Theme/editorTheme";
 import { EmbedsArray } from "./Embeds";
 
-function Editor({ dispatch, defaultValue, isPreview, isNew }) {
+function Editor({ dispatch, defaultValue, isPreview, isNew, onChange }) {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
 
@@ -34,6 +34,7 @@ function Editor({ dispatch, defaultValue, isPreview, isNew }) {
     } else {
       localStorage.setItem("bearpost.savedUpdate", text);
     }
+    onChange(value);
     handleAuthRefresh();
   }, 400);
 

--- a/frontend/components/Editor/EditorStyled.js
+++ b/frontend/components/Editor/EditorStyled.js
@@ -133,3 +133,8 @@ export const ImageInputWrapper = styled.div`
   flex-direction: row;
   align-items: center;
 `;
+
+export const ToggleButtonWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;

--- a/frontend/components/Editor/EditorWrapper.js
+++ b/frontend/components/Editor/EditorWrapper.js
@@ -1,12 +1,22 @@
 import Router from "next/router";
 import { useEffect, useState } from "react";
 import { WidthWrapper } from "../DashboardLayout/dashboardLayoutStyled";
-import { Divider, Snackbar, LinearProgress } from "@material-ui/core";
-import { Alert } from "@material-ui/lab";
-import { Visibility as VisibilityIcon } from "@material-ui/icons";
+import {
+  Divider,
+  Snackbar,
+  LinearProgress,
+  Grow,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import { Alert, ToggleButton } from "@material-ui/lab";
+import {
+  Visibility as VisibilityIcon,
+  Edit as EditIcon,
+} from "@material-ui/icons";
 import Editor from "./Editor";
 import MetaForm from "./MetaForm";
-import { StyledFab } from "./EditorStyled";
+import { StyledFab, ToggleButtonWrapper } from "./EditorStyled";
 
 const EditorWrapper = ({ query }) => {
   // SNACKBAR
@@ -25,6 +35,8 @@ const EditorWrapper = ({ query }) => {
   const [postData, setPostData] = useState({});
   const [isPreview, setIsPreview] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const [viewRaw, setViewRaw] = useState(false);
+  const [editorValue, setEditorValue] = useState("");
 
   useEffect(() => {
     // "Cancel" promise if component is not mounted
@@ -44,6 +56,7 @@ const EditorWrapper = ({ query }) => {
           if (isSubscribed && json.success) {
             console.log("Post ID: " + json.data.id);
             setPostData(json.data);
+            setEditorValue(json.data.body);
             setIsError(false);
             setMessage("Found post!");
             setShowMessage(true);
@@ -79,19 +92,71 @@ const EditorWrapper = ({ query }) => {
       {!loaded && <LinearProgress />}
       {loaded && (
         <>
-          <StyledFab
-            aria-label="preview"
-            onClick={() => {
-              setIsPreview(!isPreview);
-            }}
-            style={{ zIndex: "999999" }}
-          >
-            <VisibilityIcon color="action" />
-          </StyledFab>
-          <MetaForm postData={postData} />
+          <Grow in={!viewRaw}>
+            <StyledFab
+              aria-label="preview"
+              onClick={() => {
+                setIsPreview(!isPreview);
+              }}
+              style={{ zIndex: "999999" }}
+            >
+              <Grow
+                in={!isPreview}
+                style={isPreview ? { display: "none" } : {}}
+              >
+                <VisibilityIcon color="action" />
+              </Grow>
+              <Grow in={isPreview}>
+                <EditIcon
+                  color="action"
+                  style={!isPreview ? { display: "none" } : {}}
+                />
+              </Grow>
+            </StyledFab>
+          </Grow>
+          <MetaForm postData={postData} disableButtons={viewRaw} />
           <WidthWrapper>
+            <ToggleButtonWrapper>
+              <ToggleButton
+                value="check"
+                selected={viewRaw}
+                onChange={() => {
+                  setViewRaw(!viewRaw);
+                }}
+              >
+                Raw
+              </ToggleButton>
+              {viewRaw && (
+                <Typography
+                  color="textSecondary"
+                  style={{ marginLeft: "10px" }}
+                >
+                  It is recommended to only edit the raw value for
+                  spell-checking
+                </Typography>
+              )}
+            </ToggleButtonWrapper>
             <Divider style={{ marginTop: "10px", marginBottom: "10px" }} />
-            <Editor defaultValue={postData.body} isPreview={isPreview} />
+            {!viewRaw ? (
+              <Editor
+                defaultValue={editorValue}
+                isPreview={isPreview}
+                onChange={(value) => {
+                  setEditorValue(value);
+                }}
+              />
+            ) : (
+              <TextField
+                name="raw"
+                fullWidth
+                multiline
+                value={editorValue}
+                onChange={(event) => {
+                  setEditorValue(event.target.value);
+                }}
+                variant="outlined"
+              />
+            )}
             <Divider style={{ marginTop: "10px", marginBottom: "10px" }} />
           </WidthWrapper>
         </>

--- a/frontend/components/Editor/MetaForm.js
+++ b/frontend/components/Editor/MetaForm.js
@@ -70,7 +70,7 @@ export const ImagePreview = ({ file }) => {
   );
 };
 
-export const MetaForm = ({ postData }) => {
+export const MetaForm = ({ postData, disableButtons }) => {
   // SNACKBAR
   const handleClose = (event, reason) => {
     if (reason === "clickaway") {
@@ -263,7 +263,7 @@ export const MetaForm = ({ postData }) => {
                   onClick={() => {
                     setShowDialog(true);
                   }}
-                  disabled={isSubmitting}
+                  disabled={isSubmitting && !disableButtons}
                 >
                   Delete
                 </EditorButtonOutlined>
@@ -277,7 +277,7 @@ export const MetaForm = ({ postData }) => {
                   submitForm();
                 }}
                 type="submit"
-                disabled={isSubmitting}
+                disabled={isSubmitting && !disableButtons}
               >
                 Save
               </EditorButton>
@@ -290,7 +290,7 @@ export const MetaForm = ({ postData }) => {
                   submitForm();
                 }}
                 type="publish"
-                disabled={isSubmitting}
+                disabled={isSubmitting && !disableButtons}
               >
                 Publish
               </EditorButton>

--- a/frontend/components/PublicLayout/publicLayoutStyled.js
+++ b/frontend/components/PublicLayout/publicLayoutStyled.js
@@ -3,11 +3,7 @@ import SearchBase from "material-ui-search-bar";
 import { Paper } from "@material-ui/core";
 import GlobalTheme from "../Theme/theme";
 
-export const CenteredContainer = ({ className, children }) => {
-  return <div className={className}>{children}</div>;
-};
-
-export const StyledCenteredContainer = styled(CenteredContainer)`
+export const StyledCenteredContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/frontend/components/PublicLayout/searchBar.js
+++ b/frontend/components/PublicLayout/searchBar.js
@@ -55,6 +55,7 @@ function SearchBar() {
           cancelOnEscape={true}
           onChange={(value) => handleChange(value)}
           onCancelSearch={() => setSearchRes([])}
+          type="search"
         />
         <Collapse in={!collapse}>
           {searchRes.map((post) => (


### PR DESCRIPTION
Adds option for editing the raw markdown value of the editor, primarily for better spell-checking compatibility.
Also sets the type attribute on the search bar input element.

Resolves #148. 
