### PR TITLE
Fix raw changes not saving and buttons not disabling

### DIFF
--- a/frontend/components/Editor/Editor.js
+++ b/frontend/components/Editor/Editor.js
@@ -1,6 +1,6 @@
 import { connect } from "react-redux";
 import { refresh } from "../../redux/auth/actions";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Snackbar } from "@material-ui/core";
 import { Alert } from "@material-ui/lab";
 import { debounce, throttle } from "lodash";
@@ -20,6 +20,14 @@ function Editor({ dispatch, defaultValue, isPreview, isNew, onChange }) {
 
     setSnackbarOpen(false);
   };
+
+  useEffect(() => {
+    if (isNew) {
+      localStorage.setItem("bearpost.saved", defaultValue);
+    } else {
+      localStorage.setItem("bearpost.savedUpdate", defaultValue);
+    }
+  }, []);
 
   // Refresh tokens every 30 seconds
   const handleAuthRefresh = throttle(() => {

--- a/frontend/components/Editor/EditorWrapper.js
+++ b/frontend/components/Editor/EditorWrapper.js
@@ -131,8 +131,8 @@ const EditorWrapper = ({ query }) => {
                   color="textSecondary"
                   style={{ marginLeft: "10px" }}
                 >
-                  It is recommended to only edit the raw value for
-                  spell-checking
+                  You must toggle off raw mode before saving to verify your
+                  changes
                 </Typography>
               )}
             </ToggleButtonWrapper>

--- a/frontend/components/Editor/MetaForm.js
+++ b/frontend/components/Editor/MetaForm.js
@@ -145,8 +145,6 @@ export const MetaForm = ({ postData, disableButtons }) => {
       ? localStorage.getItem("bearpost.savedUpdate")
       : localStorage.getItem("bearpost.saved");
 
-    console.log(body);
-
     const params = {
       title: formRef.current.values.title,
       subtitle: formRef.current.values.subtitle,
@@ -263,7 +261,7 @@ export const MetaForm = ({ postData, disableButtons }) => {
                   onClick={() => {
                     setShowDialog(true);
                   }}
-                  disabled={isSubmitting && !disableButtons}
+                  disabled={isSubmitting || disableButtons}
                 >
                   Delete
                 </EditorButtonOutlined>
@@ -277,7 +275,7 @@ export const MetaForm = ({ postData, disableButtons }) => {
                   submitForm();
                 }}
                 type="submit"
-                disabled={isSubmitting && !disableButtons}
+                disabled={isSubmitting || disableButtons}
               >
                 Save
               </EditorButton>
@@ -290,7 +288,7 @@ export const MetaForm = ({ postData, disableButtons }) => {
                   submitForm();
                 }}
                 type="publish"
-                disabled={isSubmitting && !disableButtons}
+                disabled={isSubmitting || disableButtons}
               >
                 Publish
               </EditorButton>


### PR DESCRIPTION
Fixes to the raw edit view:
- Action buttons not disabling during raw edit view
- Edits in the raw view did not save when no edits were made after in rich-text view