### PR TITLE
Add v1.2.0 changes

### DIFF
--- a/backend/controllers/post.go
+++ b/backend/controllers/post.go
@@ -171,8 +171,9 @@ func (pc *PostController) GetPage(w http.ResponseWriter, r *http.Request) {
 			if val.Err() != nil {
 				log.Println("[WARN] Failed to add category posts to cache")
 				log.Println(err)
+			} else {
+				log.Println("Category query result added to cache")
 			}
-			log.Println("Category query result added to cache")
 		}
 	}
 
@@ -296,8 +297,9 @@ func (pc *PostController) GetPageAdmin(w http.ResponseWriter, r *http.Request) {
 		if val.Err() != nil {
 			log.Println("[WARN] Failed to add posts to admin cache")
 			log.Println(err)
+		} else {
+			log.Println("Query result added to admin cache")
 		}
-		log.Println("Query result added to admin cache")
 	}
 
 	NewAPIResponse(&APIResponse{Success: true, Data: posts, Pagination: &postPaginator}, w, http.StatusOK)
@@ -311,10 +313,41 @@ func (pc *PostController) GetByID(w http.ResponseWriter, r *http.Request) {
 		NewAPIError(&APIError{false, "Invalid request", http.StatusBadRequest}, w)
 		return
 	}
+
+	resStatus, resCache := pc.checkIDCache(id)
+	if resStatus {
+		var res APIResponse
+		err := json.Unmarshal(resCache, &res)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Println("[INFO] Returned result from cache")
+		NewAPIResponse(&res, w, http.StatusOK)
+		return
+	}
+
 	post, err := pc.PostRepository.FindByID(id)
 	if err != nil {
 		NewAPIError(&APIError{false, "Could not find post", http.StatusNotFound}, w)
 		return
+	} else {
+		//Add query result to Redis cache
+		jPosts, err := json.Marshal(&APIResponse{Success: true, Data: post})
+		if err != nil {
+			log.Println("[WARN] Failed to add posts to cache")
+			log.Println(err)
+			// Still send result, but failed to add to cache
+			NewAPIResponse(&APIResponse{Success: true, Data: post}, w, http.StatusOK)
+			return
+		}
+
+		val := pc.App.Redis.HSet("ID-hash", string(id), []byte(jPosts))
+		if val.Err() != nil {
+			log.Println("[WARN] Failed to add posts to cache")
+			log.Println(err)
+		} else {
+			log.Println("Query result added to ID cache")
+		}
 	}
 
 	NewAPIResponse(&APIResponse{Success: true, Data: post}, w, http.StatusOK)
@@ -394,8 +427,9 @@ func (pc *PostController) GetBySlug(w http.ResponseWriter, r *http.Request) {
 		if val.Err() != nil {
 			log.Println("[WARN] Failed to add posts to cache")
 			log.Println(err)
+		} else {
+			log.Println("Query result added to cache")
 		}
-		log.Println("Query result added to cache")
 	}
 
 	NewAPIResponse(&APIResponse{Success: true, Data: post}, w, http.StatusOK)
@@ -456,8 +490,9 @@ func (pc *PostController) GetBySlugAdmin(w http.ResponseWriter, r *http.Request)
 		if val.Err() != nil {
 			log.Println("[WARN] Failed to add posts to admin cache")
 			log.Println(err)
+		} else {
+			log.Println("Query result added to admin cache")
 		}
-		log.Println("Query result added to admin cache")
 	}
 
 	NewAPIResponse(&APIResponse{Success: true, Data: post}, w, http.StatusOK)
@@ -576,6 +611,7 @@ func (pc *PostController) Create(w http.ResponseWriter, r *http.Request) {
 	pc.flushCache()
 	pc.flushTagsCache(tags)
 	pc.flushSlugCache(slug)
+	pc.flushIDCache()
 	pc.flushAdminCache()
 	pc.flushAdminSlugCache(slug)
 
@@ -689,6 +725,7 @@ func (pc *PostController) Update(w http.ResponseWriter, r *http.Request) {
 	pc.flushCache()
 	pc.flushTagsCache(tags)
 	pc.flushSlugCache(slug)
+	pc.flushIDCache()
 	pc.flushAdminCache()
 	pc.flushAdminSlugCache(slug)
 
@@ -718,6 +755,7 @@ func (pc *PostController) Delete(w http.ResponseWriter, r *http.Request) {
 	pc.flushCache()
 	pc.flushTagsCache(post.Tags)
 	pc.flushSlugCache(post.Slug)
+	pc.flushIDCache()
 	pc.flushAdminCache()
 	pc.flushAdminSlugCache(post.Slug)
 
@@ -790,6 +828,20 @@ func (pc *PostController) checkSlugCache(slug string) (bool, []byte) {
 	return true, []byte(val)
 }
 
+// Returns if given ID is in id cache
+func (pc *PostController) checkIDCache(id int) (bool, []byte) {
+
+	val := pc.App.Redis.HGet("ID-hash", string(id))
+	if val.Val() == "" {
+		log.Println("[INFO] Key " + string(id) + " not found in ID cache")
+		return false, []byte("")
+	} else if val.Err() != nil {
+		panic(val.Err())
+	}
+	log.Println("[INFO] Key " + string(id) + " found in ID cache")
+	return true, []byte(val.Val())
+}
+
 // Returns if given category is in category cache
 func (pc *PostController) checkCategoryCache(category string, key string) (bool, []byte) {
 
@@ -852,6 +904,16 @@ func (pc *PostController) flushSlugCache(slug string) {
 		return
 	}
 	log.Println("[INFO] Flushed tags slug cache")
+	return
+}
+
+// Flushes ID cache
+func (pc *PostController) flushIDCache() {
+	err := pc.App.Redis.Del("ID-hash")
+	if err.Err() != nil {
+		log.Println(err.Err())
+	}
+	log.Println("[INFO] Flushed ID hash")
 	return
 }
 

--- a/backend/controllers/post.go
+++ b/backend/controllers/post.go
@@ -628,6 +628,12 @@ func (pc *PostController) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	subtitle, err := j.GetString("subtitle")
+	if err != nil {
+		NewAPIError(&APIError{false, "Subtitle is required", http.StatusBadRequest}, w)
+		return
+	}
+
 	body, err := j.GetString("body")
 	if err != nil {
 		NewAPIError(&APIError{false, "Content is required", http.StatusBadRequest}, w)
@@ -667,6 +673,7 @@ func (pc *PostController) Update(w http.ResponseWriter, r *http.Request) {
 	//post.UserID = uid
 	post.UpdatedAt = pgtype.Timestamptz{Time: time.Now(), Status: pgtype.Present}
 	post.Title = title
+	post.Subtitle = subtitle
 	post.Body = body
 	post.Slug = slug
 	post.Hidden = hidden

--- a/frontend/components/Editor/EditorStyled.js
+++ b/frontend/components/Editor/EditorStyled.js
@@ -28,6 +28,9 @@ export const StyledEditor = styled(Editor)`
     line-height: 1.25;
     margin: 1rem 0px 0.5rem;
   }
+  a {
+    color: #ff3d6d;
+  }
 `;
 
 export const StyledYoutubeEmbed = styled.iframe`

--- a/frontend/components/PostLayout/postLayoutSyled.js
+++ b/frontend/components/PostLayout/postLayoutSyled.js
@@ -19,3 +19,10 @@ export const WidthWrapper = styled.div`
   width: 95%;
   margin: auto;
 `;
+
+export const DateShareWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 5px;
+`;

--- a/frontend/config.json
+++ b/frontend/config.json
@@ -1,6 +1,6 @@
 {
   "blogName": "Bear Post Blog",
-  "blogDescription": "Personal Blog",
+  "blogDescription": "Example Blog",
   "blogURL": "https://example.aqchen.com",
   "numPrimaryLinks": 3,
   "navlinks": [

--- a/frontend/pages/[year]/[month]/[slug]/index.js
+++ b/frontend/pages/[year]/[month]/[slug]/index.js
@@ -44,6 +44,10 @@ const Index = (props) => {
   return (
     <Layout>
       <Head>
+        <meta
+          property="og:url"
+          content={config.blogURL + "/" + props.post.data.slug}
+        />
         <meta property="og:title" content={props.post.data.title} key="title" />
         <meta
           property="og:description"

--- a/frontend/pages/[year]/[month]/[slug]/index.js
+++ b/frontend/pages/[year]/[month]/[slug]/index.js
@@ -1,16 +1,28 @@
+import { useState } from "react";
 import Layout from "../../../../components/PostLayout/postLayout";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import fetch from "isomorphic-unfetch";
 import Error from "../../../404";
 import ReadOnlyEditor from "../../../../components/Editor/ReadOnlyEditor";
-import { Typography, Box, Divider, Link } from "@material-ui/core";
+import {
+  Typography,
+  Box,
+  Divider,
+  Link,
+  Button,
+  Tooltip,
+} from "@material-ui/core";
+import { Link as LinkIcon } from "@material-ui/icons";
 import { Skeleton } from "@material-ui/lab";
 import FeatureImage from "../../../../components/Posts/Page/PostCard/featureImage";
 import { timestamp2date } from "../../../../components/utils/helpers";
+import { DateShareWrapper } from "../../../../components/PostLayout/postLayoutSyled";
 import config from "../../../../config.json";
 
 const Index = (props) => {
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
   const router = useRouter();
 
   if (router.isFallback) {
@@ -86,19 +98,46 @@ const Index = (props) => {
         variant="subtitle1"
         color="textPrimary"
         component="h2"
-        gutterBottom
+        gutterBottom={false}
       >
         <Box fontSize={18}>{props.post.data.subtitle}</Box>
       </Typography>
-      <Typography
-        align="left"
-        variant="subtitle2"
-        color="textSecondary"
-        gutterBottom
-      >
-        {props.dateF}
-        {props.updateF && " (updated " + props.updateF + ")"}
-      </Typography>
+      <DateShareWrapper>
+        <Typography
+          align="left"
+          variant="subtitle2"
+          color="textSecondary"
+          gutterBottom={false}
+        >
+          {props.dateF}
+          {props.updateF && " (updated " + props.updateF + ")"}
+        </Typography>
+        <div>
+          <Tooltip
+            title="Copied permalink to clipboard!"
+            open={tooltipOpen}
+            arrow
+            placement="top"
+            onClose={() => {
+              setTooltipOpen(false);
+            }}
+            leaveDelay={1000}
+          >
+            <Button
+              size="small"
+              onClick={async () => {
+                await navigator.clipboard
+                  .writeText(config.blogURL + "/perma/" + props.post.data.id)
+                  .then(() => {
+                    setTooltipOpen(true);
+                  });
+              }}
+            >
+              <LinkIcon />
+            </Button>
+          </Tooltip>
+        </div>
+      </DateShareWrapper>
       <FeatureImage
         featureImgUrl={props.post.data.featureImgUrl}
         tags={props.post.data.tags}

--- a/frontend/pages/[year]/[month]/[slug]/index.js
+++ b/frontend/pages/[year]/[month]/[slug]/index.js
@@ -1,4 +1,5 @@
 import Layout from "../../../../components/PostLayout/postLayout";
+import Head from "next/head";
 import { useRouter } from "next/router";
 import fetch from "isomorphic-unfetch";
 import Error from "../../../404";
@@ -42,6 +43,19 @@ const Index = (props) => {
 
   return (
     <Layout>
+      <Head>
+        <meta property="og:title" content={props.post.data.title} key="title" />
+        <meta
+          property="og:description"
+          content={props.post.data.subtitle}
+          key="description"
+        />
+        <meta
+          property="og:image"
+          content={props.post.data.FeatureImage}
+          key="image"
+        />
+      </Head>
       <Typography align="left" color="textPrimary" variant="h1" component="h1">
         <Box fontWeight={500} fontSize={"2.5rem"}>
           {props.post.data.title}

--- a/frontend/pages/[year]/[month]/[slug]/index.js
+++ b/frontend/pages/[year]/[month]/[slug]/index.js
@@ -8,6 +8,7 @@ import { Typography, Box, Divider, Link } from "@material-ui/core";
 import { Skeleton } from "@material-ui/lab";
 import FeatureImage from "../../../../components/Posts/Page/PostCard/featureImage";
 import { timestamp2date } from "../../../../components/utils/helpers";
+import config from "../../../../config.json";
 
 const Index = (props) => {
   const router = useRouter();

--- a/frontend/pages/[year]/[month]/[slug]/index.js
+++ b/frontend/pages/[year]/[month]/[slug]/index.js
@@ -46,6 +46,18 @@ const Index = (props) => {
     <Layout>
       <Head>
         <meta
+          name="twitter:url"
+          content={config.blogURL + "/" + props.post.data.slug}
+        />
+        <meta name="twitter:title" content={props.post.data.title} />
+        <meta name="twitter:description" content={props.post.data.subtitle} />
+        <meta
+          name="twitter:image"
+          content={
+            process.env.NEXT_PUBLIC_API_URL + props.post.data.featureImgUrl
+          }
+        />
+        <meta
           property="og:url"
           content={config.blogURL + "/" + props.post.data.slug}
         />
@@ -57,7 +69,9 @@ const Index = (props) => {
         />
         <meta
           property="og:image"
-          content={props.post.data.FeatureImage}
+          content={
+            process.env.NEXT_PUBLIC_API_URL + props.post.data.featureImgUrl
+          }
           key="image"
         />
       </Head>

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -10,6 +10,7 @@ import SCtheme from "../assets/theme/SCtheme";
 import useScrollRestoration from "../components/utils/useScrollRestoration";
 import { RouteIndicator } from "../components/Theme/routeIndicator";
 import * as gtag from "../components/utils/gtag";
+import config from "../config.json";
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -25,7 +26,7 @@ const App = ({ Component, pageProps, router }) => {
   return (
     <React.Fragment>
       <Head>
-        <title>Bear Post</title>
+        <title>{config.blogName}</title>
         <meta
           name="viewport"
           content="minimum-scale=1, initial-scale=1, width=device-width"

--- a/frontend/pages/_document.js
+++ b/frontend/pages/_document.js
@@ -75,23 +75,9 @@ export default class Document extends NextDocument {
           />
 
           <meta name="twitter:card" content="summary" />
-          <meta name="twitter:url" content={config.blogURL} />
-          <meta name="twitter:title" content={config.blogName} />
-          <meta name="twitter:description" content={config.blogDescription} />
-          <meta
-            name="twitter:image"
-            content={
-              config.blogURL +
-              "/static/icons/android/android-launchericon-192-192.png"
-            }
-          />
           <meta name="twitter:creator" content={config.blogName} />
           <meta property="og:type" content="website" />
           <meta property="og:site_name" content={config.blogName} />
-          <meta
-            property="og:image"
-            content={config.blogURL + "/static/icons/apple-touch-icon.png"}
-          />
         </Head>
         <body content={theme.palette.background}>
           <Main />

--- a/frontend/pages/_document.js
+++ b/frontend/pages/_document.js
@@ -87,12 +87,6 @@ export default class Document extends NextDocument {
           />
           <meta name="twitter:creator" content={config.blogName} />
           <meta property="og:type" content="website" />
-          <meta property="og:title" content={config.blogName} key="title" />
-          <meta
-            property="og:description"
-            content={config.blogDescription}
-            key="description"
-          />
           <meta property="og:site_name" content={config.blogName} />
           <meta property="og:url" content={config.blogURL} />
           <meta

--- a/frontend/pages/_document.js
+++ b/frontend/pages/_document.js
@@ -88,7 +88,6 @@ export default class Document extends NextDocument {
           <meta name="twitter:creator" content={config.blogName} />
           <meta property="og:type" content="website" />
           <meta property="og:site_name" content={config.blogName} />
-          <meta property="og:url" content={config.blogURL} />
           <meta
             property="og:image"
             content={config.blogURL + "/static/icons/apple-touch-icon.png"}

--- a/frontend/pages/_document.js
+++ b/frontend/pages/_document.js
@@ -87,8 +87,12 @@ export default class Document extends NextDocument {
           />
           <meta name="twitter:creator" content={config.blogName} />
           <meta property="og:type" content="website" />
-          <meta property="og:title" content={config.blogName} />
-          <meta property="og:description" content="Best PWA App in the world" />
+          <meta property="og:title" content={config.blogName} key="title" />
+          <meta
+            property="og:description"
+            content={config.blogDescription}
+            key="description"
+          />
           <meta property="og:site_name" content={config.blogName} />
           <meta property="og:url" content={config.blogURL} />
           <meta

--- a/frontend/pages/category/[category]/index.js
+++ b/frontend/pages/category/[category]/index.js
@@ -17,7 +17,7 @@ const Index = ({ initialData }) => {
           name="twitter:url"
           content={config.blogURL + "/category/" + category}
         />
-        <meta name="twitter:title" content={category} />
+        <meta name="twitter:title" content={"Category: " + category} />
         <meta name="twitter:description" content={config.blogDescription} />
         <meta
           name="twitter:image"
@@ -38,7 +38,11 @@ const Index = ({ initialData }) => {
           property="og:url"
           content={config.blogURL + "/category/" + category}
         />
-        <meta property="og:title" content={category} key="title" />
+        <meta
+          property="og:title"
+          content={"Category: " + category}
+          key="title"
+        />
         <meta
           property="og:description"
           content={config.blogDescription}

--- a/frontend/pages/category/[category]/index.js
+++ b/frontend/pages/category/[category]/index.js
@@ -14,6 +14,11 @@ const Index = ({ initialData }) => {
     <Layout>
       <Head>
         <meta property="og:title" content={category} key="title" />
+        <meta
+          property="og:description"
+          content={config.blogDescription}
+          key="description"
+        />
       </Head>
       <HeaderWrapper>
         <Typography

--- a/frontend/pages/category/[category]/index.js
+++ b/frontend/pages/category/[category]/index.js
@@ -13,6 +13,10 @@ const Index = ({ initialData }) => {
   return (
     <Layout>
       <Head>
+        <meta
+          property="og:url"
+          content={config.blogURL + "/category/" + category}
+        />
         <meta property="og:title" content={category} key="title" />
         <meta
           property="og:description"

--- a/frontend/pages/category/[category]/index.js
+++ b/frontend/pages/category/[category]/index.js
@@ -13,8 +13,11 @@ const Index = ({ initialData }) => {
   return (
     <Layout>
       <Head>
-        <meta name="twitter:url" content={config.blogURL} />
-        <meta name="twitter:title" content={config.blogName} />
+        <meta
+          name="twitter:url"
+          content={config.blogURL + "/category/" + category}
+        />
+        <meta name="twitter:title" content={category} />
         <meta name="twitter:description" content={config.blogDescription} />
         <meta
           name="twitter:image"

--- a/frontend/pages/category/[category]/index.js
+++ b/frontend/pages/category/[category]/index.js
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import Head from "next/head";
 import { Typography } from "@material-ui/core";
 import Layout from "../../../components/PublicLayout/publicLayout";
 import { HeaderWrapper } from "../../../components/PublicLayout/publicLayoutStyled";
@@ -11,6 +12,9 @@ const Index = ({ initialData }) => {
 
   return (
     <Layout>
+      <Head>
+        <meta property="og:title" content={category} key="title" />
+      </Head>
       <HeaderWrapper>
         <Typography
           align="center"

--- a/frontend/pages/category/[category]/index.js
+++ b/frontend/pages/category/[category]/index.js
@@ -13,6 +13,24 @@ const Index = ({ initialData }) => {
   return (
     <Layout>
       <Head>
+        <meta name="twitter:url" content={config.blogURL} />
+        <meta name="twitter:title" content={config.blogName} />
+        <meta name="twitter:description" content={config.blogDescription} />
+        <meta
+          name="twitter:image"
+          content={
+            config.blogURL +
+            "/static/icons/android/android-launchericon-192-192.png"
+          }
+        />
+        <meta
+          property="og:image"
+          content={
+            config.blogURL +
+            "/static/icons/android/android-launchericon-192-192.png"
+          }
+          key="image"
+        />
         <meta
           property="og:url"
           content={config.blogURL + "/category/" + category}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -15,6 +15,24 @@ const Index = ({ initialData }) => {
           content={config.blogDescription}
           key="description"
         />
+        <meta
+          property="og:image"
+          content={
+            config.blogURL +
+            "/static/icons/android/android-launchericon-192-192.png"
+          }
+          key="image"
+        />
+        <meta name="twitter:url" content={config.blogURL} />
+        <meta name="twitter:title" content={config.blogName} />
+        <meta name="twitter:description" content={config.blogDescription} />
+        <meta
+          name="twitter:image"
+          content={
+            config.blogURL +
+            "/static/icons/android/android-launchericon-192-192.png"
+          }
+        />
       </Head>
       <PostsContainer category="" initialData={initialData} />
     </Layout>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -8,6 +8,7 @@ const Index = ({ initialData }) => {
   return (
     <Layout>
       <Head>
+        <meta property="og:url" content={config.blogURL} />
         <meta property="og:title" content={config.blogName} key="title" />
         <meta
           property="og:description"

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,10 +1,20 @@
+import Head from "next/head";
 import Layout from "../components/PublicLayout/publicLayout";
 import PostsContainer from "../components/Posts/postsContainer";
 import fetch from "isomorphic-unfetch";
+import config from "../config.json";
 
 const Index = ({ initialData }) => {
   return (
     <Layout>
+      <Head>
+        <meta property="og:title" content={config.blogName} key="title" />
+        <meta
+          property="og:description"
+          content={config.blogDescription}
+          key="description"
+        />
+      </Head>
       <PostsContainer category="" initialData={initialData} />
     </Layout>
   );

--- a/frontend/pages/perma/[id]/index.js
+++ b/frontend/pages/perma/[id]/index.js
@@ -1,0 +1,90 @@
+import { useEffect } from "react";
+import Layout from "../../../components/PostLayout/postLayout";
+import { useRouter } from "next/router";
+import fetch from "isomorphic-unfetch";
+import Error from "../../404";
+import { Typography } from "@material-ui/core";
+import { Skeleton } from "@material-ui/lab";
+
+const Index = ({ post }) => {
+  const router = useRouter();
+
+  if (router.isFallback) {
+    return (
+      <Layout>
+        <Typography
+          align="left"
+          color="textPrimary"
+          variant="h1"
+          component="h1"
+        >
+          <Skeleton variant="text" width="80%" />
+        </Typography>
+        <Typography
+          align="left"
+          variant="subtitle1"
+          color="textPrimary"
+          component="h2"
+          gutterBottom
+        >
+          <Skeleton variant="text" width="40%" />
+        </Typography>
+        <Skeleton variant="rect" width="100%" height={"600px"} />
+      </Layout>
+    );
+  }
+
+  if (!post.success) {
+    return <Error />;
+  } else {
+    useEffect(() => {
+      router.replace("/" + post.data.slug);
+    }, []);
+
+    return (
+      <Layout>
+        <Typography
+          align="left"
+          color="textPrimary"
+          variant="h1"
+          component="h1"
+        >
+          <Skeleton variant="text" width="80%" />
+        </Typography>
+        <Typography
+          align="left"
+          variant="subtitle1"
+          color="textPrimary"
+          component="h2"
+          gutterBottom
+        >
+          <Skeleton variant="text" width="40%" />
+        </Typography>
+        <Skeleton variant="rect" width="100%" height={"600px"} />
+      </Layout>
+    );
+  }
+};
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: true,
+  };
+}
+
+export async function getStaticProps(context) {
+  let res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/posts/${context.params.id}`
+  );
+  const post = await res.json();
+
+  return {
+    revalidate: 3,
+    props: {
+      post: post,
+    },
+  };
+}
+
+export default Index;


### PR DESCRIPTION
Adds the following functionality:
- Add the option to edit and existing post's raw body value (this is great for spell-checkers like Grammarly since they usually don't play nice with WYSIWYG editors)
- Add better open graph and twitter metadata that changes depending on the page (great for pasting links in applications that use them like Discord)
- Add support for permalinks
  - Permalinks take the form /perma/[id] and will redirect the user to the post's page, great for if the post title changes later on
  - In support of this, the backend now has a Redis hash cache for post ID's

Resolves #148, resolves #154, and resolves #151.